### PR TITLE
Override built-in mark mappings

### DIFF
--- a/autoload/ostroga.vim
+++ b/autoload/ostroga.vim
@@ -26,6 +26,7 @@ function! ostroga#update_global_marks()
     endfor
 endfunction
 
+" TODO: Add fallback for neovim compatible popup
 function! ostroga#popup_create()
     return popup_create(ostroga#ui#marks_to_hints(s:global_alpha_marks()), {
         \ 'filter': function('s:choose_mark'),

--- a/autoload/ostroga.vim
+++ b/autoload/ostroga.vim
@@ -28,14 +28,24 @@ endfunction
 
 " TODO: Add fallback for neovim compatible popup
 function! ostroga#popup_create()
-    return popup_create(ostroga#ui#marks_to_hints(s:global_alpha_marks()), {
-        \ 'filter': function('s:choose_mark'),
-        \
-        \ 'title': '  Jump to mark',
-        \ 'border': [1, 1, 1, 1],
-        \ 'borderchars': ['┈', '⸽', '┈', '⸽', '✨', '✨', '✨', '✨'],
-        \ 'mapping': v:false,
-        \ 'highlight': 'Normal',
-        \ 'borderhighlight': ['Statement'],
-    \})
+    if(!has('nvim'))
+      return popup_create(ostroga#ui#marks_to_hints(s:global_alpha_marks()), {
+          \ 'filter': function('s:choose_mark'),
+          \
+          \ 'title': '  Jump to mark',
+          \ 'border': [1, 1, 1, 1],
+          \ 'borderchars': ['┈', '⸽', '┈', '⸽', '✨', '✨', '✨', '✨'],
+          \ 'mapping': v:false,
+          \ 'highlight': 'Normal',
+          \ 'borderhighlight': ['Statement'],
+      \})
+    else
+        let width = float2nr(&columns * 0.6)
+        let height = float2nr(&lines * 0.6)
+        let top = ((&lines - height) / 2) - 1
+        let left = (&columns - width) / 2
+        let opts = {'relative': 'editor', 'row': top, 'col': left, 'width': width, 'height': height, 'style': 'minimal', 'border': 'rounded'}
+        let s:buf = nvim_create_buf(v:false, v:true)
+        return nvim_open_win(s:buf, v:true, opts)
+    endif
 endfunction

--- a/plugin/ostroga.vim
+++ b/plugin/ostroga.vim
@@ -8,6 +8,11 @@ let g:loaded_ostroga_plugin = 1
 
 command -nargs=0 OstrogaJump call ostroga#popup_create()
 
+nmap ' :OstrogaJump<CR>
+omap ' :OstrogaJump<CR>
+nmap ` :OstrogaJump<CR>
+omap ` :OstrogaJump<CR>
+
 augroup ostroga_update_global_marks
     au!
     autocmd BufLeave * call ostroga#update_global_marks()


### PR DESCRIPTION
Inspiration for this _hacky POC_ came from junegunn's vim-peekaboo. I thought it would be nice to not have to think about a separate mapping while still retaining all the benefits of this plugin.

Love this project idea, keep it up :tada: 